### PR TITLE
Fix mariadb character set to utf8mb4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   db:
     container_name: wconsys-db
     image: mariadb:10.2
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
     environment:
       - MYSQL_ROOT_PASSWORD=hogehoge123
       - MYSQL_DATABASE=wconsys


### PR DESCRIPTION
日本語が登録できなかったため修正